### PR TITLE
Adding jurisdiction_id into POST Service Request message if provided

### DIFF
--- a/three/core.py
+++ b/three/core.py
@@ -225,6 +225,8 @@ class Three(object):
     def _post_keywords(self, **kwargs):
         """Configure keyword arguments for Open311 POST requests."""
         code = kwargs.pop('code')
+        if self.jurisdiction and 'jurisdiction_id' not in kwargs:
+            kwargs['jurisdiction_id'] = self.jurisdiction
         if 'address' in kwargs:
             address = kwargs.pop('address')
             kwargs['address_string'] = address


### PR DESCRIPTION
If jurisdiction is set, it is added as parameter into GET messages (services, requests,..) but not into POST Service Request message. This change will add jurisdiction_id into the POST message if it has been provided.
