### PR TITLE
Do not override self.request in Three.post()

### DIFF
--- a/three/core.py
+++ b/three/core.py
@@ -220,9 +220,9 @@ class Three(object):
         else:
             files = None
         url = self._create_path('requests')
-        self.request = requests.post(url, data=kwargs, files=files)
-        content = self.request.content
-        if self.request.status_code == 200:
+        self.post_response = requests.post(url, data=kwargs, files=files)
+        content = self.post_response.content
+        if self.post_response.status_code == 200:
             conversion = True
         else:
             conversion = False


### PR DESCRIPTION
requests.post() returns an object of Response type. Instead of
overriding Three.request(), store the response with the name
'post_response'.
