### PR TITLE
Update to Python3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,5 @@ python:
   - "2.6"
   - "2.7"
   - "3.6"
-install: pip install -r requirements.txt --use-mirrors
+install: pip install -r requirements.txt
 script: python test.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,6 @@ language: python
 python:
   - "2.6"
   - "2.7"
+  - "3.6"
 install: pip install -r requirements.txt --use-mirrors
 script: python test.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ simplejson
 # Testing
 #------------------
 mock
+responses

--- a/three/cities.py
+++ b/three/cities.py
@@ -10,7 +10,7 @@ class CityNotFound(Exception):
 def find_info(name=None):
     """Find the needed city server information."""
     if not name:
-        return servers.keys()
+        return list(servers.keys()) 
     name = name.lower()
     if name in servers:
         info = servers[name]

--- a/three/core.py
+++ b/three/core.py
@@ -6,11 +6,18 @@ import os
 import re
 from collections import defaultdict
 from datetime import date
-from itertools import ifilter
+
 
 import requests
 from relaxml import xml
 import simplejson as json
+
+try:
+    # Python 2
+    from future_builtins import filter
+except ImportError:
+    # Python 3
+    pass
 
 
 class SSLAdapter(requests.adapters.HTTPAdapter):
@@ -19,10 +26,11 @@ class SSLAdapter(requests.adapters.HTTPAdapter):
         self.ssl_version = ssl_version
         super(SSLAdapter, self).__init__(**kwargs)
 
-    def init_poolmanager(self, connections, maxsize):
+    def init_poolmanager(self, connections, maxsize, block):
         self.poolmanager = requests.packages.urllib3.poolmanager.PoolManager(
             num_pools=connections,
             maxsize=maxsize,
+            block=block,
             ssl_version=self.ssl_version)
 
 
@@ -92,7 +100,7 @@ class Three(object):
 
     def _create_path(self, *args):
         """Create URL path for endpoint and args."""
-        args = ifilter(None, args)
+        args = filter(None, args)
         path = self.endpoint + '/'.join(args) + '.%s' % (self.format)
         return path
 
@@ -155,7 +163,7 @@ class Three(object):
             data = json.loads(content)
         elif self.format == 'xml':
             content = xml(content)
-            first = content.keys()[0]
+            first = list(content.keys())[0]
             data = content[first]
         else:
             data = content


### PR DESCRIPTION
__What__

This pull request updates the Three client library to work under Python3.6, and to work with the latest version of the Requests library that has changed the signature of the HTTPAdaptor class.

__How to review__

1. Clone
2. Check the tests pass
3. Consider if more test coverage is required.

